### PR TITLE
English parser cannot handle `torn`

### DIFF
--- a/anki-vocabulary-osx.el
+++ b/anki-vocabulary-osx.el
@@ -236,7 +236,7 @@ It returns an alist like
   "Parse QUERIED from English dictionary."
   (let ((separator " | ")
         (keywords anki-vocabulary-keywords)
-        (word-limit 50)
+        (word-limit (min 50 (length queried)))
         expression glossary phonetic
         mb me)
     (if (null (string-match separator (substring queried 0 word-limit)))


### PR DESCRIPTION
Here I want to memorize the word `torn` with its captured context:
> I'm torn. The formalist part of me says I don't care.
If anyone has interest on where I got this phrase, I leave a link: https://youtu.be/Dp-mQ3HxgDE?t=4258.#